### PR TITLE
Alter responsive behaviour, and default texture loading issue

### DIFF
--- a/src/Globe.ts
+++ b/src/Globe.ts
@@ -450,29 +450,28 @@ export default class Globe {
     const globeClouds = this.getObjectByName(ObjectName.GlobeClouds) as Mesh;
     const globeSphere = this.getObjectByName(ObjectName.GlobeSphere) as Mesh;
 
-    new TextureLoader().load(texture, map => {
-      globeSphere.geometry = new SphereGeometry(
-        RADIUS,
-        GLOBE_SEGMENTS,
-        GLOBE_SEGMENTS,
-      );
-      globeSphere.material = new MeshLambertMaterial({
-        map,
-      });
-      if (enableGlow) {
-        globeSphere.remove(this.getObjectByName(ObjectName.GlobeGlow));
-        const globeGlow = createGlowMesh(globeSphere.geometry, {
-          backside: true,
-          color: glowColor,
-          coefficient: glowCoefficient,
-          power: glowPower,
-          size: RADIUS * glowRadiusScale,
-        });
-        globeGlow.name = ObjectName.GlobeGlow;
-        globeSphere.add(globeGlow);
-      }
-      this.callbacks.onTextureLoaded();
+    let map = new TextureLoader().load(texture);
+    globeSphere.geometry = new SphereGeometry(
+      RADIUS,
+      GLOBE_SEGMENTS,
+      GLOBE_SEGMENTS,
+    );
+    globeSphere.material = new MeshLambertMaterial({
+      map,
     });
+    if (enableGlow) {
+      globeSphere.remove(this.getObjectByName(ObjectName.GlobeGlow));
+      const globeGlow = createGlowMesh(globeSphere.geometry, {
+        backside: true,
+        color: glowColor,
+        coefficient: glowCoefficient,
+        power: glowPower,
+        size: RADIUS * glowRadiusScale,
+      });
+      globeGlow.name = ObjectName.GlobeGlow;
+      globeSphere.add(globeGlow);
+    }
+    this.callbacks.onTextureLoaded();
 
     if (enableBackground) {
       new TextureLoader().load(backgroundTexture, map => {
@@ -730,6 +729,7 @@ export default class Globe {
       const [width, height] = size;
       this.renderer.setSize(width, height);
       this.camera.aspect = width / height;
+      this.camera.fov = (height > width) ? (height / width) * CAMERA_FOV : CAMERA_FOV;
     }
     this.camera.updateProjectionMatrix();
   }

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -13,7 +13,7 @@ import {
 export const RADIUS = 300;
 export const BACKGROUND_RADIUS_SCALE = 10;
 export const CAMERA_FAR = RADIUS * 100;
-export const CAMERA_FOV = 45;
+export const CAMERA_FOV = 66;
 export const CAMERA_NEAR = 1;
 export const CAMERA_DAMPING_FACTOR = 0.1;
 export const CAMERA_MAX_POLAR_ANGLE = Math.PI;


### PR DESCRIPTION
Updated camera FOV to help with responsive display - addresses https://github.com/chrisrzhou/react-globe/issues/22

Updated texture loaded to prevent race condition - addresses https://github.com/chrisrzhou/react-globe/issues/20

The solution to this one looks wrong but works because TextureLoader().load() returns a texture that can be used immediately. Using the callback allows for a slower loading texture to overwrite a faster one. The large-ish default globe texture can take longer to load than the user specified one, and can replace the texture that is actually desired. I can see this behaviour popping up in the demos as well as my own project.

